### PR TITLE
Make boot order explicit (NVMe then CD-ROM).

### DIFF
--- a/src/linux/create_guest_disk_image.rs
+++ b/src/linux/create_guest_disk_image.rs
@@ -292,11 +292,11 @@ fn install_via_qemu(ctx: &mut Context, ui: &dyn Ui) -> Result<()> {
         "virtio-net-pci,netdev=net0",
         "-device",
         "nvme,drive=drivec,serial=01de01de,physical_block_size=512,\
-                logical_block_size=512,discard_granularity=512",
+                logical_block_size=512,discard_granularity=512,bootindex=1",
         "-drive",
         &install_disk_arg,
         "-device",
-        "ide-cd,drive=win-disk,id=cd-disk0,unit=0,bus=ide.0",
+        "ide-cd,drive=win-disk,id=cd-disk0,unit=0,bus=ide.0,bootindex=2",
         "-drive",
         &windows_iso_arg,
         "-device",


### PR DESCRIPTION
I was getting dropped in the EDK2 shell running wimsy interactively (+ VGA console). Explicitly marking the NVMe drive as the first boot option, followed by the Windows Installer ISO backed CD-ROM has it working for me with no touch.

On first boot it'll try and fail to load from the newly created disk image before continuing onto the setup ISO:
```
BdsDxe: failed to load Boot0004 "UEFI QEMU NVMe Ctrl 01de01de 1" from PciRoot(0x0)/Pci(0x4,0x0)/NVMe(0x1,00-00-00-00-00-00-00-00): Not Found
BdsDxe: loading Boot0001 "UEFI QEMU DVD-ROM QM00001 " from PciRoot(0x0)/Pci(0x1,0x1)/Ata(Primary,Master,0x0)
BdsDxe: starting Boot0001 "UEFI QEMU DVD-ROM QM00001 " from PciRoot(0x0)/Pci(0x1,0x1)/Ata(Primary,Master,0x0)
```

On reboot it correctly boots from the freshly installed windows on the disk:
```
BdsDxe: loading Boot0002 "Windows Boot Manager" from HD(2,GPT,A7F06756-FAA6-4E79-82AA-D74D45EF8190,0xFA800,0x32000)/\EFI\Microsoft\Boot\bootmgfw.efi
BdsDxe: starting Boot0002 "Windows Boot Manager" from HD(2,GPT,A7F06756-FAA6-4E79-82AA-D74D45EF8190,0xFA800,0x32000)/\EFI\Microsoft\Boot\bootmgfw.efi
```