### PR TITLE
Add OpenSSH install for Server 2016

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,10 @@ images contain the following drivers, software, and settings:
     the Oxide web console and CLI.
   - [OpenSSH for
     Windows](https://learn.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse?tabs=powershell)
-    is installed via PowerShell cmdlet. This operation requires Internet access.
+    is installed via PowerShell cmdlet (Windows Server 2019 and 2022) or by
+    downloading the latest
+    [release](https://github.com/PowerShell/Win32-OpenSSH/releases/) from
+    GitHub. This operation requires the guest to have Internet access.
   - The guest is configured to allow Remote Desktop connections, and the guest
     firewall is configured to accept connections on port 3389. **Note:** VMs
     using these images must also have their firewall rules set to accept

--- a/unattend/OxidePrepBaseImage.ps1
+++ b/unattend/OxidePrepBaseImage.ps1
@@ -124,7 +124,6 @@ if ($?) {
     Write-Host "SSH capability not present in image, will download from GitHub"
     $sshPath = "C:\Windows\Temp\OpenSSH-Win64.zip"
     RetryWithBackoff -ScriptBlock { DownloadLatestSshArchive -ArchivePath $sshPath }
-    DownloadLatestSshArchive -ArchivePath $sshPath
     InstallSshFromArchive -ArchivePath $sshPath
 }
 


### PR DESCRIPTION
Windows Server 2016 doesn't support installing OpenSSH via DISM/`Add-WindowsCapability`, so get the latest OpenSSH from GitHub instead and install it manually.

Posting as a draft since I'm still uploading/testing the WS2016 image generated this way (and I'd also like to make sure the WS2019/2022 behavior is still correct).

Fixes #2.