### PR TITLE
v0.1.0: update package version too

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "wimsy"
-version = "0.1.0-beta.1"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wimsy"
-version = "0.1.0-beta.1"
+version = "0.1.0"
 edition = "2021"
 repository = "https://github.com/oxidecomputer/windows-image-builder"
 


### PR DESCRIPTION
Rookie mistake: forgot to update the Cargo package version before pushing the release tag, which `cargo dist` understandably doesn't like. Should've run `cargo dist plan` on the local before pushing the tag.