### PR TITLE
Update unattend xml to include productkey element option

### DIFF
--- a/unattend/Autounattend.xml
+++ b/unattend/Autounattend.xml
@@ -86,8 +86,9 @@
             </ImageInstall>
             <UserData>
                 <AcceptEula>true</AcceptEula>
+                <!-- Update and uncomment Product Key if applicable -->
                 <ProductKey>
-                    <Key>12345-12345-12345-12345-12345</Key>
+                    <!--<Key>12345-12345-12345-12345-12345</Key>-->
                     <WillShowUI>Never</WillShowUI>
                 </ProductKey>
             </UserData>

--- a/unattend/Autounattend.xml
+++ b/unattend/Autounattend.xml
@@ -86,6 +86,10 @@
             </ImageInstall>
             <UserData>
                 <AcceptEula>true</AcceptEula>
+                <ProductKey>
+                    <Key>12345-12345-12345-12345-12345</Key>
+                    <WillShowUI>Never</WillShowUI>
+                </ProductKey>
             </UserData>
         </component>
     </settings>


### PR DESCRIPTION
Added the `<ProductKey>` element to `<UserData>` in the XML file to add the key for building a Windows image if users are using a retail or volume license ISO.

Not sure if the entire <ProductKey> element needs commenting out; please feel free to adjust.