### PR TITLE
Document using wimage to get index

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,3 +189,15 @@ images contain the following drivers, software, and settings:
     `authorized_keys`.
   - The OS installation volume is automatically extended to include the entire
     boot disk, even if it is larger than the original image.
+
+# Determining the `/IMAGE/INDEX` for your Windows version
+
+The index used for a given Windows version will vary by iso file.
+You can use the `wimtools` package to find the versions available on your image:
+
+```sh
+# On a debian-based Linux host
+$ sudo apt-get install wimtools 7zip
+$ 7z e '-ir!install.wim' <WIN_ISO>
+$ wiminfo sources/install.wim
+```


### PR DESCRIPTION
Update the README to document how to use `wimage` to find the indices of the Windows versions available on an iso.