### PR TITLE
Updates and modifications for ease of use on Linux

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,0 +1,286 @@
+:showtitle:
+:toc: left
+:toclevels: 2
+:icons: font
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
+= Windows Image Builder
+
+image:https://img.shields.io/badge/platform-linux-green.svg[Linux]
+image:https://img.shields.io/badge/status-active-blue.svg[Status]
+
+This repository provides tooling and automation for building customized Windows Server disk images on modern Linux hosts, designed for upload and use with the Oxide platform.
+
+This project has been designed to handle both Illumos and Linux as build platforms, however this README is focused on the Linux build process. The illumos build process is documented in a separate README.
+
+The imgbuild.sh script is the main entry point for building Windows images on Linux. It orchestrates the entire process, from validating inputs to creating the final image.
+
+toc::[]
+
+== Requirements
+
+To build images successfully on Linux, the following prerequisites must be met:
+
+- **Operating System:** Ubuntu 20.04+ or related distributions (others may work but are not tested).
+- **Nested Virtualization:** Required. Your system must support `vmx` (Intel) or `svm` (AMD). On cloud VMs (e.g. AWS/GCP), this usually requires special instance types that expose nested virtualization.
+- **Privileges:** Depending on how your system is configured, scripts may require `sudo` access to create VMs and configure bridges. The script tries to check for this and will prompt if needed.
+- **Tools:** See `install_prerequisites.sh` to install:
+  - `qemu-kvm`, `virt-install`, `libvirt-daemon`, `libguestfs-tools`, `genisoimage`, `virtio-win`, etc.
+- **Internet Access:** Required to download updates and dependencies during install.
+
+== Quickstart
+
+=== 1. Install Dependencies
+
+Run:
+
+```bash
+./install_prerequisites.sh
+```
+
+=== 2. Configure Build Environment
+
+Create and edit the environment file - these variables must be set in your `imgbuild.env` file before running the builder. Each controls a key part of the image creation process. A sample file is provided for reference and can be copied to start:
+
+```bash
+cp imgbuild.env.sample imgbuild.env
+```
+
+[cols="1,3"]
+|===
+| Variable | Description
+
+| `WORK_DIR`
+| Path to a scratch workspace directory used for temporary files, log output, and intermediate image artifacts.
+
+| `OUTPUT_IMAGE`
+| Full path to the resulting raw disk image (`.img` or `.raw`) that will be produced by the build.
+
+| `WINDOWS_ISO`
+| Path to the Windows Server installation ISO (2019 or 2022 recommended).
+
+| `VIRTIO_ISO`
+| Path to the VirtIO driver ISO, used to inject storage and network drivers during Windows setup.
+
+| `UNATTEND_DIR`
+| Directory containing your `Autounattend.xml` file, which automates the Windows installation process.
+
+| `OVMF_PATH`
+| Path to the OVMF firmware file (e.g. `OVMF_CODE.fd`), used for UEFI boot with `qemu`. Common location: `/var/lib/libvirt/images/OVMF_CODE.fd`.
+
+|===
+
+NOTE: All paths must be absolute. Relative paths may not resolve correctly within virtualized builds.
+
+=== 3. Build the Image
+
+```bash
+./imgbuild.sh
+```
+
+This drives the full flow using modular scripts in `imgbuild.d/`.
+
+== Submodule Breakdown
+
+Each stage in the `imgbuild.d/` directory is responsible for a key phase of the build:
+
+[cols="1,3"]
+|===
+| Script | Description
+
+| `run-all`
+| Virtual module that runs all of the submodules in order.
+| `check_system.sh`
+| Verifies all required tools are present and working (`qemu`, `genisoimage`, `libguestfs`).
+
+| `validate_inputs.sh`
+| Ensures `imgbuild.env` is loaded, validates ISO paths, product keys, and environment assumptions.
+
+| `build_app.sh`
+| Compiles the Rust-based `wimsy` CLI tool, which assists with image metadata and preparation.
+
+| `build_image.sh`
+| The main action:
+  - Spins up a temporary VM using `virt-install`.
+  - Mounts the VirtIO ISO and the Windows ISO.
+  - Injects the provided `Autounattend.xml`.
+  - Waits for installation to complete.
+  - Converts and shrinks the resulting disk image.
+|===
+
+To run a specific phase individually:
+
+```bash
+./imgbuild.d/build_image.sh phase
+```
+
+(Ensure your environment is sourced beforehand.)
+
+== Output Format
+
+This process produces a `.raw` file in **raw disk image format**.
+
+IMPORTANT: The **Oxide rack only accepts raw disk images** for upload. Other formats like VMDK or QCOW2 will not work.
+
+Your output will be something like:
+
+```bash
+output/windows-2022.raw
+```
+
+IMPORTANT: This image will be fairly large, roughly 13-15GB for most basic installations.
+
+== Download Links
+
+=== Official Windows ISOs
+
+- https://www.microsoft.com/en-us/evalcenter/evaluate-windows-server-2022
+- https://www.microsoft.com/en-us/evalcenter/evaluate-windows-server-2019
+
+Use the **ISO for installation and evaluation**; this is what we use for testing. Licensing is the responsibility of the user.
+
+=== VirtIO Driver ISO
+
+- https://github.com/virtio-win/virtio-win-pkg-scripts/blob/master/README.md
+
+Ensure this is accessible at the path defined in your `.env` file.
+
+== Unattended Windows Installation
+
+To fully automate Windows installation, this project uses Microsoft's Autounattend.xml system.
+
+Example configuration lives in:
+
+```bash
+unattend/Autounattend.xml
+```
+
+To customize:
+
+- Set timezone, locale, keyboard, disk layout.
+- Add user credentials.
+- Configure product key injection.
+
+Resources for learning and modifying:
+
+- Microsoft Docs: https://docs.microsoft.com/en-us/windows-hardware/customize/desktop/unattend/
+- Answer file generator: https://www.windowsafg.com
+
+
+== Additional Image Customization Options
+
+The wimsy tool runs an unattended Windows Setup session using the files found in the directory specified by the `--unattend-dir` argument. These files can be modified directly, or you can pass flags to alter behavior dynamically
+
+`--unattend-image-index`: Overrides the ImageIndex in the Autounattend.xml. This allows you to choose a specific Windows edition (e.g., Standard vs. Datacenter, with or without Desktop Experience).
+
+`--windows-version`: Rewrites driver paths in Autounattend.xml to match a specific Windows version, ensuring the correct VirtIO drivers are used.
+
+`--vga-console`: (Linux only) Starts QEMU with VGA output so you can watch or interact with the Windows installation via console.
+
+WARNING: You need to have a DISPLAY configured to use the VGA console option. This will silently fail if you set it and do not have a DISPLAY.
+
+NOTE: If you are using the `ingbuild.sh` script you will need to adjust the `build-image.sh` module. This module is responsible for calling wimsy and passing the correct arguments.
+
+== Default Image Configuration
+
+The images created by wimsy and this build system are fully generalized:
+https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep--generalize--a-windows-installation?view=windows-11[What is Generalization?]
+
+They can be reused across multiple VMs. The default image includes:
+
+Drivers:
+
+- virtio-net for networking support
+- virtio-block for disk support
+
+User Accounts:
+
+- The default Administrator account is disabled.
+- A local user named oxide is created and added to the Administrators group.
+- SSH keys from Oxide instance metadata are injected into oxide's authorized_keys.
+- No password is set by default. You can assign one later using:
+
+```cmd
+net user oxide *
+```
+
+Remote Access:
+
+- EMS (Emergency Management Services) is enabled on COM1. Accessible via the Oxide console (Web or CLI).
+- OpenSSH is installed via PowerShell (Add-WindowsCapability) or from GitHub if needed.
+- RDP is enabled and firewall rules are pre-configured to allow port 3389.
+
+NOTE: Instance-level firewall rules must also allow access to port 3389 for RDP to function externally.
+
+In-Guest Agents: Installs an Oxide-compatible fork of https://cloudbase-init.readthedocs.io/en/latest/[Cloudbase-Init]:
+
+- Metadata is read from the NoCloud config drive.
+- Hostname is set automatically to match the Oxide instance name.
+- SSH key injection is configured for the oxide user.
+- The system drive is auto-expanded to match the VM disk size at boot.
+
+== Finding the Correct Windows Image Index
+
+Each Windows ISO may contain multiple editions (e.g., Standard, Datacenter, Core). You must set the correct image index in Autounattend.xml.
+
+To inspect available indexes:
+
+```bash
+# On a Debian/Ubuntu-based host
+sudo apt-get install wimtools p7zip-full
+7z e '-ir!install.wim' /path/to/windows.iso
+wiminfo install.wim
+```
+
+Use the /IMAGE/INDEX that corresponds to your desired edition.
+
+== Uploading to Oxide
+
+Once the .raw file is generated, it can be uploaded to your Oxide silo as a custom image.
+
+=== Upload via CLI
+
+```bash
+oxide disk import \
+--project yourproject \
+--path yourimage.raw \
+--disk disk-name \
+--disk-block-size 512 \
+--description "Windows on Oxide" \
+--snapshot win-2022 \
+--image win-2022 \
+--image-description "Windows with Oxide"
+--image-os windows --image-version 2022
+```
+
+CLI docs: https://oxide.computer/docs/cli/oxide_disk_import
+
+=== Upload via Web UI
+
+1. Visit your Oxide console.
+2. Navigate to the "Images" section.
+3. Click "Import Disk".
+4. Provide a name, description, os type, and version. Then add your .raw file and import the image.
+5. Now you can deploy an instance using this image.
+
+More information: https://oxide.computer/docs/ui/image-import
+
+== illumos Support
+
+While this project has pivoted toward a Linux-first experience, full support for illumos-based systems continues.
+
+If you're using an illumos host (such as SmartOS or OmniOS), please refer to the dedicated documentation:
+
+→ link:README.illumos.md[README.illumos.md – Illumos Instructions]
+
+== Roadmap
+
+- Integration with Oxide CLI for direct uploads
+- Add support for Windows 2016
+- Support for external app layer injection (e.g., Chocolatey or WinRM)

--- a/README.illumos.md
+++ b/README.illumos.md
@@ -1,0 +1,203 @@
+# Windows Image Builder
+
+This repo contains the `wimsy` command-line tool for constructing generic
+Windows Server images that can be imported into an Oxide rack and used to
+create new Windows-based instances. This tool sets up Windows in a VM running
+on your computer, automatically customizes that installation using scripts that
+you supply, and minimizes the size of the installation disk once setup is
+complete. You can then upload the installation disk to an Oxide rack and attach
+it to a VM or use it as the source disk for a new disk image.
+
+`wimsy` runs on Linux (tested on Ubuntu 20.04) and illumos systems and supports
+creating Windows Server 2019 and Windows Server 2022 images. Windows Server
+2016 is not yet fully supported (but it's on the roadmap). Earlier versions of
+Windows Server and client editions of Windows are not supported. It may be
+possible to use `wimsy` to generate images for these versions, but Oxide has
+not tested them, so your mileage may vary.
+
+# Usage
+
+## Prerequisites
+
+### Host machine configuration
+
+When using the repo's default setup scripts, the guest VM must be able to reach
+the Internet to download guest software, so the host must have a network
+connection. See the [default image configuration](#default-image-configuration)
+for more information about what these scripts install.
+
+### Tools
+
+Run `install_prerequisites.sh` from the repo or release tarball to install the
+tools `wimsy` invokes to create disks and run VMs. On Linux hosts, a Debian
+(aptitude-based) package manager is required. Linux systems use the following
+tools and packages:
+
+* `qemu` and `ovmf` to run the Windows installer in a virtual machine
+* `qemu-img` and `libguestfs-tools` to create and manage virtual disks and their
+  filesystems
+* `sgdisk` to modify virtual disks' GUID partition tables
+* `genisoimage` to create an ISO containing the unattended setup scripts
+
+### Installation media & drivers
+
+`wimsy` requires an ISO disk image containing Windows installation media, an ISO
+disk image containing signed virtio drivers, and a UEFI guest firmware image to
+use when running the setup VM.
+
+Oxide tests Windows guests using the [driver
+images](https://github.com/virtio-win/virtio-win-pkg-scripts/blob/master/README.md)
+created by the Fedora Project. If you use another driver ISO, the drivers must
+be arranged in the same directory structure used by this project.
+
+On a Linux system with virtualization tools installed, a guest firmware image
+from the OVMF project can generally be found in `/usr/share/OVMF/OVMF_CODE.fd`.
+
+### Setup scripts
+
+`wimsy` uses a number of scripts to run an unattended Windows Setup process and
+customize an image's software and settings. Oxide tests images using lightly
+modified version of the scripts in the `unattend` directory in this repo, but
+you can modify these or provide custom scripts. At a minimum, an
+`Autounattend.xml` answer file is required to run Windows Setup unattended. See
+Microsoft's documentation of the [Windows Setup
+process](https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/windows-setup-installation-process?view=windows-11)
+and the [Unattended Windows Setup
+Reference](https://learn.microsoft.com/en-us/windows-hardware/customize/desktop/unattend/)
+for details.
+
+`wimsy` expects all the unattend scripts it will inject to reside in a single
+flat directory. The `unattend` directory in this repo contains a set of scripts
+that apply the [default image configuration](#default-image-configuration)
+described below.
+
+## Running `wimsy`
+
+### From a release tarball
+
+Unpack the tarball and install the prerequisite tools, then run `wimsy`,
+substituting the appropriate paths to your input ISOs and output disk image:
+
+```bash
+./install_prerequisites.sh
+
+./wimsy \
+--work-dir /tmp \
+--output-image $OUTPUT_IMAGE_PATH \
+create-guest-disk-image \
+--windows-iso $WINDOWS_SETUP_ISO_PATH \
+--virtio-iso $VIRTIO_DRIVER_ISO_PATH \
+--unattend-dir unattend \
+--ovmf-path /usr/share/OVMF/OVMF_CODE.fd \
+```
+
+For more information, run `wimsy --help` or `wimsy create-guest-disk-image
+--help`.
+
+### Building from source
+
+Build with `cargo` and view the command-line help as follows:
+
+```bash
+cargo build --release
+target/release/wimsy create-guest-disk-image --help
+```
+
+Then invoke `wimsy` with your desired arguments, e.g.:
+
+```bash
+target/release/wimsy \
+--work-dir /tmp \
+--output-image $OUTPUT_IMAGE_PATH \
+create-guest-disk-image \
+--windows-iso $WINDOWS_SETUP_ISO_PATH \
+--virtio-iso $VIRTIO_DRIVER_ISO_PATH \
+--unattend-dir ./unattend \
+--ovmf-path /usr/share/OVMF/OVMF_CODE.fd \
+```
+
+### Running on illumos
+
+Running on illumos requires some extra configuration:
+
+- If you are using the setup scripts in the `unattend` directory, copy them to
+  another directory, then replace `Autounattend.xml` and `prep.cmd` with
+  `illumos/Autounattend.xml` and `illumos/prep.cmd` from the repo.
+- You'll need to run `wimsy build-installation-disk` before running `wimsy
+  create-guest-disk-image`. See the command-line help for more information.
+
+## Additional options
+
+`wimsy` runs an unattended Windows Setup session driven by the files and scripts
+in the directory passed to `--unattend-dir`. You can modify these files directly
+to customize your image, but `wimsy` provides some command line switches to
+apply common modifications:
+
+- The `--unattend-image-index` switch changes the image index specified in
+  `Autounattend.xml`, which changes the Windows edition Setup will attempt to
+  install (e.g. selecting between Server Standard and Server Datacenter with or
+  without a Desktop Experience Pack).
+- The `--windows-version` switch rewrites the driver paths in `Autounattend.xml`
+  to install virtio drivers corresponding to a specific Windows version.
+
+When running on Linux, adding the `--vga-console` switch directs QEMU to run
+with a VGA console attached to the guest so that you can watch and interact with
+Windows Setup visually.
+
+# Default image configuration
+
+`wimsy` and the unattend scripts in this repo create
+[generalized](https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep--generalize--a-windows-installation?view=windows-11)
+images that can be uploaded to the rack and used to create multiple VMs. These
+images contain the following drivers, software, and settings:
+
+- **Drivers**: `virtio-net` and `virtio-block` device drivers will be installed.
+- **User accounts**: The local administrator account is disabled. An account
+  with username `oxide` will be created and added to the Local Administrators
+  group. Any SSH keys that are associated with an instance when that instance is
+  created will be added to the `oxide` user's authorized keys. By default, this
+  account has no password; to set a password, access the machine via SSH and use
+  `net user oxide *`.
+- **Remote access**:
+  - The [Emergency Management Services
+    console](https://learn.microsoft.com/en-us/windows-hardware/drivers/devtest/boot-parameters-to-enable-ems-redirection)
+    is enabled and accessible over COM1. This console will be accessible through
+    the Oxide web console and CLI.
+  - [OpenSSH for
+    Windows](https://learn.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse?tabs=powershell)
+    is installed via PowerShell cmdlet (Windows Server 2019 and 2022) or by
+    downloading the latest
+    [release](https://github.com/PowerShell/Win32-OpenSSH/releases/) from
+    GitHub. This operation requires the guest to have Internet access.
+  - The guest is configured to allow Remote Desktop connections, and the guest
+    firewall is configured to accept connections on port 3389. **Note:** VMs
+    using these images must also have their firewall rules set to accept
+    connections on this port for RDP to be accessible.
+- **In-guest agents**: The scripts install an Oxide-compatible
+  [fork](https://github.com/luqmana/cloudbase-init/tree/oxide) of
+  [cloudbase-init](https://cloudbase-init.readthedocs.io/en/latest/) that
+  initializes new VMs when they are run for the first time. This operation
+  requires Internet access. `cloudbase-init` is configured with the following
+  settings and plugins:
+  - Instance metadata will be read from the no-cloud configuration drive the
+    Oxide control plane attaches to each running instance.
+  - The instance's computer name will be set to its Oxide instance hostname on
+    first boot.
+  - The built-in administrator account is disabled. An `oxide` account is
+    in the Local Administrators group is created in its place. Any SSH keys
+    provided in the instance's metadata will be added to this user's
+    `authorized_keys`.
+  - The OS installation volume is automatically extended to include the entire
+    boot disk, even if it is larger than the original image.
+
+# Determining the `/IMAGE/INDEX` for your Windows version
+
+The index used for a given Windows version will vary by iso file.
+You can use the `wimtools` package to find the versions available on your image:
+
+```sh
+# On a debian-based Linux host
+$ sudo apt-get install wimtools 7zip
+$ 7z e '-ir!install.wim' <WIN_ISO>
+$ wiminfo sources/install.wim
+```

--- a/imgbuild.d/build_app.sh
+++ b/imgbuild.d/build_app.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "📦 Checking for Rust application (wimsy)..."
+
+WIMSY_BIN="./target/release/wimsy"
+
+# Check if binary already exists
+if [[ -x "$WIMSY_BIN" ]]; then
+  echo "✅ Rust binary already built: $WIMSY_BIN"
+  exit 0
+fi
+
+# Check if Cargo is available
+if ! command -v cargo >/dev/null; then
+  echo "❌ Cargo is not installed or not in PATH."
+  echo "   Please install Rust: https://www.rust-lang.org/tools/install"
+  exit 1
+fi
+
+# Build using cargo in release mode
+echo "🔨 Building wimsy using: cargo build --release"
+cargo build --release
+
+# Confirm build result
+if [[ -x "$WIMSY_BIN" ]]; then
+  echo "✅ Build successful. Executable located at $WIMSY_BIN"
+else
+  echo "❌ Build failed or output binary not found."
+  exit 1
+fi
+

--- a/imgbuild.d/build_image.sh
+++ b/imgbuild.d/build_image.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "🖥️  Starting Windows image build process..."
+
+# Load environment variables
+ENV_FILE="imgbuild.env"
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "❌ Configuration file '$ENV_FILE' not found."
+  echo "   Please create it first."
+  exit 1
+fi
+
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+
+# Validate required variables
+required_vars=(
+  WORK_DIR
+  OUTPUT_IMAGE
+  WINDOWS_ISO
+  VIRTIO_ISO
+  UNATTEND_DIR
+  OVMF_PATH
+)
+
+missing_vars=()
+
+for var in "${required_vars[@]}"; do
+  if [[ -z "${!var:-}" ]]; then
+    missing_vars+=("$var")
+  fi
+done
+
+if (( ${#missing_vars[@]} )); then
+  echo "❌ Missing required environment variables:"
+  printf '  - %s\n' "${missing_vars[@]}"
+  exit 1
+fi
+
+# Check if wimsy binary exists
+WIMSY_BIN="./target/release/wimsy"
+if [[ ! -x "$WIMSY_BIN" ]]; then
+  echo "❌ wimsy binary not found. Please build it first using ./build.sh build-rust."
+  exit 1
+fi
+
+# Build the command line
+CMD=(
+  "$WIMSY_BIN"
+  --work-dir "$WORK_DIR"
+  --output-image "$OUTPUT_IMAGE"
+  create-guest-disk-image
+  --windows-iso "$WINDOWS_ISO"
+  --virtio-iso "$VIRTIO_ISO"
+  --unattend-dir "$UNATTEND_DIR"
+  --ovmf-path "$OVMF_PATH"
+)
+
+# Handle VGA_CONSOLE if set
+if [[ "${VGA_CONSOLE:-false}" == "true" ]]; then
+  # Check if an X display is available
+  if [[ -n "${DISPLAY:-}" ]]; then
+    echo "🖥️  VGA console requested and X display found: $DISPLAY"
+    CMD+=(--vga-console)
+  else
+    echo "⚠️  VGA console requested but no DISPLAY available. Skipping VGA console option."
+  fi
+fi
+
+# Show the command for visibility
+echo "🔧 Running: ${CMD[*]}"
+
+# Run the build command
+"${CMD[@]}"
+
+echo "✅ Windows image build completed."
+

--- a/imgbuild.d/check_system.sh
+++ b/imgbuild.d/check_system.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "🛠️  Checking system compatibility..."
+
+errors=()
+
+# Check if script is run as root or with sudo when needed
+if [[ "$(id -u)" -ne 0 ]]; then
+  echo "⚠️  Some checks will require elevated permissions (sudo)."
+  echo "   This is needed to:"
+  echo "   - Verify and set iptables NAT rules"
+  echo "   - Enable IP forwarding if needed"
+  echo "   - Inspect system-wide configurations"
+  echo ""
+fi
+
+# Check KVM availability
+if [[ ! -e /dev/kvm ]]; then
+    errors+=("❌ KVM device not found. Is virtualization enabled in your BIOS?")
+fi
+
+if ! groups | grep -q '\bkvm\b'; then
+    errors+=("❌ You are not in the 'kvm' group. Add yourself with:")
+    errors+=("   sudo usermod -aG kvm $USER && newgrp kvm")
+fi
+
+# Check QEMU availability
+if ! command -v qemu-system-x86_64 >/dev/null; then
+    errors+=("❌ qemu-system-x86_64 not found. Please install QEMU.")
+fi
+
+# Check Rust / Cargo availability
+if ! command -v cargo >/dev/null || ! command -v rustc >/dev/null; then
+    errors+=("❌ Rust and/or Cargo are not installed or not in your PATH.")
+    errors+=("   Please visit https://www.rust-lang.org/tools/install to install Rust.")
+fi
+
+# Determine which packages are required
+required_pkgs=(qemu-system-x86 qemu-utils genisoimage wimtools gdisk curl unzip)
+missing_pkgs=()
+
+for pkg in "${required_pkgs[@]}"; do
+    if ! dpkg -s "$pkg" &>/dev/null; then
+        missing_pkgs+=("$pkg")
+    fi
+done
+
+if (( ${#missing_pkgs[@]} )); then
+    echo "📦 The following packages are missing and will be installed:"
+    printf '  - %s\n' "${missing_pkgs[@]}"
+    if [[ -x "./install_prerequisites.sh" ]]; then
+        echo "🔧 Running install_prerequisites.sh..."
+        ./install_prerequisites.sh
+    else
+        errors+=("❌ Missing required packages: ${missing_pkgs[*]}")
+        errors+=("   And install_prerequisites.sh was not found or executable.")
+    fi
+fi
+
+# Ensure iptables MASQUERADE rule exists
+if ! sudo iptables -t nat -C POSTROUTING -s 10.0.0.0/8 -j MASQUERADE 2>/dev/null; then
+    echo "⚠️  Adding MASQUERADE rule for 10.0.0.0/8..."
+    sudo iptables -t nat -A POSTROUTING -s 10.0.0.0/8 -j MASQUERADE
+fi
+
+# Ensure IP forwarding is enabled
+if [[ "$(sysctl -n net.ipv4.ip_forward)" -ne 1 ]]; then
+    echo "⚠️  Enabling IP forwarding..."
+    sudo sysctl -w net.ipv4.ip_forward=1
+fi
+
+# Report results
+if (( ${#errors[@]} )); then
+    echo ""
+    echo "🚫 Some system requirements are not met:"
+    for err in "${errors[@]}"; do
+        echo "  $err"
+    done
+    exit 1
+else
+    echo "✅ System check passed."
+fi

--- a/imgbuild.d/check_system.sh
+++ b/imgbuild.d/check_system.sh
@@ -59,16 +59,16 @@ if (( ${#missing_pkgs[@]} )); then
 fi
 
 # Ensure iptables MASQUERADE rule exists
-if ! sudo iptables -t nat -C POSTROUTING -s 10.0.0.0/8 -j MASQUERADE 2>/dev/null; then
-    echo "⚠️  Adding MASQUERADE rule for 10.0.0.0/8..."
-    sudo iptables -t nat -A POSTROUTING -s 10.0.0.0/8 -j MASQUERADE
-fi
+#if ! sudo iptables -t nat -C POSTROUTING -s 10.0.0.0/8 -j MASQUERADE 2>/dev/null; then
+    #echo "⚠️  Adding MASQUERADE rule for 10.0.0.0/8..."
+    #sudo iptables -t nat -A POSTROUTING -s 10.0.0.0/8 -j MASQUERADE
+#fi
 
 # Ensure IP forwarding is enabled
-if [[ "$(sysctl -n net.ipv4.ip_forward)" -ne 1 ]]; then
-    echo "⚠️  Enabling IP forwarding..."
-    sudo sysctl -w net.ipv4.ip_forward=1
-fi
+#if [[ "$(sysctl -n net.ipv4.ip_forward)" -ne 1 ]]; then
+    #echo "⚠️  Enabling IP forwarding..."
+    #sudo sysctl -w net.ipv4.ip_forward=1
+#fi
 
 # Report results
 if (( ${#errors[@]} )); then

--- a/imgbuild.d/check_system.sh
+++ b/imgbuild.d/check_system.sh
@@ -2,6 +2,9 @@
 set -euo pipefail
 
 echo "🛠️  Checking system compatibility..."
+echo "     "
+echo "⚠️  This has been tested on Ubuntu Noble and uses Ubuntu packages"
+echo "    Your mileage may vary with other Ubuntu versisons and derivatives"
 
 errors=()
 
@@ -9,31 +12,36 @@ errors=()
 if [[ "$(id -u)" -ne 0 ]]; then
   echo "⚠️  Some checks will require elevated permissions (sudo)."
   echo "   This is needed to:"
-  echo "   - Verify and set iptables NAT rules"
-  echo "   - Enable IP forwarding if needed"
+  echo "   - Install packages"
   echo "   - Inspect system-wide configurations"
   echo ""
 fi
 
+# Tell me about the system
+if command -v hostnamectl >/dev/null; then
+  hostnamectl
+fi
+
 # Check KVM availability
 if [[ ! -e /dev/kvm ]]; then
-    errors+=("❌ KVM device not found. Is virtualization enabled in your BIOS?")
+  errors+=("❌ KVM device not found. Is virtualization enabled in your BIOS?")
 fi
 
 if ! groups | grep -q '\bkvm\b'; then
-    errors+=("❌ You are not in the 'kvm' group. Add yourself with:")
-    errors+=("   sudo usermod -aG kvm $USER && newgrp kvm")
+  errors+=("❌ You are not in the 'kvm' group. Add yourself with:")
+  errors+=("   sudo usermod -aG kvm $USER && newgrp kvm")
 fi
 
 # Check QEMU availability
 if ! command -v qemu-system-x86_64 >/dev/null; then
-    errors+=("❌ qemu-system-x86_64 not found. Please install QEMU.")
+  errors+=("❌ qemu-system-x86_64 not found. Please install QEMU.")
 fi
 
 # Check Rust / Cargo availability
 if ! command -v cargo >/dev/null || ! command -v rustc >/dev/null; then
-    errors+=("❌ Rust and/or Cargo are not installed or not in your PATH.")
-    errors+=("   Please visit https://www.rust-lang.org/tools/install to install Rust.")
+  errors+=("❌ Rust and/or Cargo are not installed or not in your PATH.")
+  errors+=("   Please visit https://www.rust-lang.org/tools/install to install Rust.")
+  errors+=("   If you're brave, you can run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh")
 fi
 
 # Determine which packages are required
@@ -41,43 +49,31 @@ required_pkgs=(qemu-system-x86 qemu-utils genisoimage wimtools gdisk curl unzip)
 missing_pkgs=()
 
 for pkg in "${required_pkgs[@]}"; do
-    if ! dpkg -s "$pkg" &>/dev/null; then
-        missing_pkgs+=("$pkg")
-    fi
+  if ! dpkg -s "$pkg" &>/dev/null; then
+    missing_pkgs+=("$pkg")
+  fi
 done
 
-if (( ${#missing_pkgs[@]} )); then
-    echo "📦 The following packages are missing and will be installed:"
-    printf '  - %s\n' "${missing_pkgs[@]}"
-    if [[ -x "./install_prerequisites.sh" ]]; then
-        echo "🔧 Running install_prerequisites.sh..."
-        ./install_prerequisites.sh
-    else
-        errors+=("❌ Missing required packages: ${missing_pkgs[*]}")
-        errors+=("   And install_prerequisites.sh was not found or executable.")
-    fi
+if ((${#missing_pkgs[@]})); then
+  echo "📦 The following packages are missing and will be installed:"
+  printf '  - %s\n' "${missing_pkgs[@]}"
+  if [[ -x "./install_prerequisites.sh" ]]; then
+    echo "🔧 Running install_prerequisites.sh..."
+    ./install_prerequisites.sh
+  else
+    errors+=("❌ Missing required packages: ${missing_pkgs[*]}")
+    errors+=("   And install_prerequisites.sh was not found or executable.")
+  fi
 fi
 
-# Ensure iptables MASQUERADE rule exists
-#if ! sudo iptables -t nat -C POSTROUTING -s 10.0.0.0/8 -j MASQUERADE 2>/dev/null; then
-    #echo "⚠️  Adding MASQUERADE rule for 10.0.0.0/8..."
-    #sudo iptables -t nat -A POSTROUTING -s 10.0.0.0/8 -j MASQUERADE
-#fi
-
-# Ensure IP forwarding is enabled
-#if [[ "$(sysctl -n net.ipv4.ip_forward)" -ne 1 ]]; then
-    #echo "⚠️  Enabling IP forwarding..."
-    #sudo sysctl -w net.ipv4.ip_forward=1
-#fi
-
 # Report results
-if (( ${#errors[@]} )); then
-    echo ""
-    echo "🚫 Some system requirements are not met:"
-    for err in "${errors[@]}"; do
-        echo "  $err"
-    done
-    exit 1
+if ((${#errors[@]})); then
+  echo ""
+  echo "🚫 Some system requirements are not met:"
+  for err in "${errors[@]}"; do
+    echo "  $err"
+  done
+  exit 1
 else
-    echo "✅ System check passed."
+  echo "✅ System check passed."
 fi

--- a/imgbuild.d/validate_inputs.sh
+++ b/imgbuild.d/validate_inputs.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "📁 Validating image build environment and inputs..."
+
+# Load config
+ENV_FILE="imgbuild.env"
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "❌ Configuration file '$ENV_FILE' not found."
+  echo "   Please create it and define required paths."
+  exit 1
+fi
+
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+
+# Required variables
+required_vars=(
+  WORK_DIR
+  OUTPUT_IMAGE
+  WINDOWS_ISO
+  VIRTIO_ISO
+  UNATTEND_DIR
+  OVMF_PATH
+)
+
+missing_vars=()
+
+for var in "${required_vars[@]}"; do
+  if [[ -z "${!var:-}" ]]; then
+    missing_vars+=("$var")
+  fi
+done
+
+if (( ${#missing_vars[@]} )); then
+  echo "❌ Missing required environment variables in '$ENV_FILE':"
+  printf '  - %s\n' "${missing_vars[@]}"
+  exit 1
+fi
+
+# File/path checks
+check_path() {
+  local label="$1"
+  local path="$2"
+  local type="$3"  # 'file' or 'dir'
+  if [[ "$type" == "file" && ! -f "$path" ]]; then
+    echo "❌ Missing file: $label ($path)"
+    return 1
+  elif [[ "$type" == "dir" && ! -d "$path" ]]; then
+    echo "❌ Missing directory: $label ($path)"
+    return 1
+  fi
+  return 0
+}
+
+errors=()
+check_path "Windows ISO" "$WINDOWS_ISO" "file" || errors+=("WINDOWS_ISO")
+check_path "VirtIO ISO" "$VIRTIO_ISO" "file" || errors+=("VIRTIO_ISO")
+check_path "Unattended Directory" "$UNATTEND_DIR" "dir" || errors+=("UNATTEND_DIR")
+check_path "OVMF Firmware" "$OVMF_PATH" "file" || errors+=("OVMF_PATH")
+check_path "Working Directory" "$WORK_DIR" "dir" || errors+=("WORK_DIR")
+
+if (( ${#errors[@]} )); then
+  echo "🚫 One or more required paths are missing or invalid:"
+  printf '  - %s\n' "${errors[@]}"
+  exit 1
+else
+  echo "✅ All required input paths are present."
+fi
+

--- a/imgbuild.env.sample
+++ b/imgbuild.env.sample
@@ -1,0 +1,22 @@
+# Sample configuration file for Windows image builder
+# Copy to "imgbuld.env" and customize for your environment
+
+# Path to a directory for temporary files
+WORK_DIR=/tmp
+
+# Path where the final image should be created
+OUTPUT_IMAGE=./SomeDir/SomeImage.raw
+
+# Path to the Windows Server ISO
+WINDOWS_ISO=./SomeDir/SomeWindowsServer.iso
+
+# Path to the VirtIO driver ISO
+VIRTIO_ISO=./SomeDir/SomeVirtio.iso
+
+# Directory containing unattended setup files (e.g., Autounattend.xml)
+# These are known working files, but can be edited for your environment
+UNATTEND_DIR=./unattend
+
+# Path to the OVMF UEFI firmware (e.g., OVMF_CODE_4M.fd)
+# This is the default on Ubuntu Noble with qemu
+OVMF_PATH=/usr/share/OVMF/OVMF_CODE_4M.fd

--- a/imgbuild.sh
+++ b/imgbuild.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Load all modules
+MODULE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/imgbuild.d" && pwd)"
+
+# Default functions
+function usage() {
+  echo "Usage: $0 [command]"
+  echo ""
+  echo "Commands:"
+  echo "  check-system   Run system checks (KVM, QEMU, firewall, dependencies)"
+  echo "  build          Run the full image build process (wimsy)"
+  echo "  validate-env   Validate required directories and files"
+  echo "  build-image    Build the Windows image using the supplied config"
+  echo ""
+  exit 1
+}
+
+# Parse command
+CMD="${1:-}"
+case "$CMD" in
+check-system)
+  bash "$MODULE_DIR/check_system.sh"
+  ;;
+build)
+  bash "$MODULE_DIR/build_app.sh"
+  ;;
+validate-env)
+  bash "$MODULE_DIR/validate_inputs.sh"
+  ;;
+build-image)
+  bash "$MODULE_DIR/build_image.sh"
+  ;;
+*)
+  usage
+  ;;
+esac
+

--- a/imgbuild.sh
+++ b/imgbuild.sh
@@ -13,6 +13,7 @@ function usage() {
   echo "  build          Run the full image build process (wimsy)"
   echo "  validate-env   Validate required directories and files"
   echo "  build-image    Build the Windows image using the supplied config"
+  echo "  run-all        Run all steps: check, validate, build app, build image"
   echo ""
   exit 1
 }
@@ -20,20 +21,30 @@ function usage() {
 # Parse command
 CMD="${1:-}"
 case "$CMD" in
-check-system)
-  bash "$MODULE_DIR/check_system.sh"
-  ;;
-build)
-  bash "$MODULE_DIR/build_app.sh"
-  ;;
-validate-env)
-  bash "$MODULE_DIR/validate_inputs.sh"
-  ;;
-build-image)
-  bash "$MODULE_DIR/build_image.sh"
-  ;;
-*)
-  usage
-  ;;
+  check-system)
+    bash "$MODULE_DIR/check_system.sh"
+    ;;
+  build)
+    bash "$MODULE_DIR/build_app.sh"
+    ;;
+  validate-env)
+    bash "$MODULE_DIR/validate_inputs.sh"
+    ;;
+  build-image)
+    bash "$MODULE_DIR/build_image.sh"
+    ;;
+  run-all)
+    echo "==> [1/4] Checking system..."
+    bash "$MODULE_DIR/check_system.sh"
+    echo "==> [2/4] Validating inputs..."
+    bash "$MODULE_DIR/validate_inputs.sh"
+    echo "==> [3/4] Building wimsy CLI tool..."
+    bash "$MODULE_DIR/build_app.sh"
+    echo "==> [4/4] Building Windows image..."
+    bash "$MODULE_DIR/build_image.sh"
+    echo "✅ All steps completed successfully."
+    ;;
+  *)
+    usage
+    ;;
 esac
-

--- a/unattend/OxidePrepBaseImage.ps1
+++ b/unattend/OxidePrepBaseImage.ps1
@@ -95,14 +95,26 @@ Enable-NetFirewallRule -DisplayGroup "Remote Desktop"
 #region Wait for internet access
 $timeout = New-TimeSpan -Seconds 30
 $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+$connected = $false
+
 do {
-    $ping = Test-NetConnection -Comp "www.oxide.computer" -Port 443
-    if ($stopwatch.elapsed -gt $timeout) {
-        Write-Host "No internet connectivity"
-        exit 1
+    $ping = Test-NetConnection -ComputerName "www.oxide.computer" -Port 443
+    if ($ping.TcpTestSucceeded) {
+        $connected = $true
+        break
     }
-} while (-not $ping)
+
+    Start-Sleep -Seconds 1
+} while ($stopwatch.Elapsed -lt $timeout)
+
+if (-not $connected) {
+    Write-Host "No internet connectivity"
+    exit 1
+} else {
+    Write-Host "Internet connection established"
+}
 #endregion
+
 
 #region Enable SSH
 Write-Host "Enabling SSH"

--- a/unattend/OxidePrepBaseImage.ps1
+++ b/unattend/OxidePrepBaseImage.ps1
@@ -96,7 +96,7 @@ Enable-NetFirewallRule -DisplayGroup "Remote Desktop"
 $timeout = New-TimeSpan -Seconds 30
 $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 do {
-    $ping = test-connection -Comp 1.1.1.1 -Count 1 -Quiet
+    $ping = Test-NetConnection -Comp "www.oxide.computer" -Port 443
     if ($stopwatch.elapsed -gt $timeout) {
         Write-Host "No internet connectivity"
         exit 1


### PR DESCRIPTION
This change adds in a number of changes to help customers more easily build images for the Oxide Rack.

Key Changes:
- New documentation focusing on the Linux use case.
- "imgbuild.sh" script and associated modules to provide a simple way to perform necessary tasks to get from iso -> image.
- Modification of internet connectivity check from ping (which does not work under qemu's default networking) to a check of port 443 on oxide.computer.
